### PR TITLE
Fix issues with logged urls in default handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function time(start) {
 function defaultHandler(request, options, cb) {
 	options = typeof options === 'string' ? urlParse(options) : options;
 
-	var url = options.href || (options.protocol || 'http://') + options.host + options.path;
+	var url = options.href || (options.protocol || 'http:') + '//' + (options.host || options.hostname) + options.path;
 	var method = (options.method || 'GET').toUpperCase();
 	var signature = method + ' ' + url;
 	var start = new Date();


### PR DESCRIPTION
1. when using `node-http-proxy` the standard handler would log an `undefined` hostname
2. when using the passed protocol instead of the fallback the `//` in the urls would be missing
